### PR TITLE
Add tests for risk, portfolio and utilities

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,143 @@
+import sys
+from types import ModuleType
+
+# Stub pandas
+pd_stub = ModuleType("pandas")
+pd_stub.DataFrame = object
+pd_stub.Series = object
+pd_stub.to_datetime = lambda x, *a, **k: x
+pd_stub.to_numeric = lambda x, *a, **k: x
+sys.modules.setdefault("pandas", pd_stub)
+
+# Stub rich modules used by progress
+class Console:
+    def __init__(self, *a, **k):
+        pass
+class Live:
+    def __init__(self, *a, **k):
+        pass
+    def start(self):
+        pass
+    def stop(self):
+        pass
+class Table:
+    def __init__(self, *a, **k):
+        self.columns = []
+    def add_column(self, *a, **k):
+        pass
+    def add_row(self, *a, **k):
+        pass
+class Style:
+    def __init__(self, *a, **k):
+        pass
+class Text:
+    def __init__(self, *a, **k):
+        pass
+    def append(self, *a, **k):
+        pass
+rich_console = ModuleType("rich.console"); rich_console.Console = Console
+rich_live = ModuleType("rich.live"); rich_live.Live = Live
+rich_table = ModuleType("rich.table"); rich_table.Table = Table
+rich_style = ModuleType("rich.style"); rich_style.Style = Style
+rich_text = ModuleType("rich.text"); rich_text.Text = Text
+sys.modules.setdefault("rich.console", rich_console)
+sys.modules.setdefault("rich.live", rich_live)
+sys.modules.setdefault("rich.table", rich_table)
+sys.modules.setdefault("rich.style", rich_style)
+sys.modules.setdefault("rich.text", rich_text)
+
+# Stub pydantic
+pydantic_stub = ModuleType("pydantic")
+class BaseModel:
+    def __init__(self, **kwargs):
+        for k, v in kwargs.items():
+            setattr(self, k, v)
+    def model_dump(self):
+        return self.__dict__
+    def json(self):
+        import json
+        return json.dumps(self.model_dump())
+
+pydantic_stub.BaseModel = BaseModel
+pydantic_stub.Field = lambda *a, **k: None
+sys.modules.setdefault("pydantic", pydantic_stub)
+
+# Stub langchain_core modules
+lang_msgs = ModuleType("langchain_core.messages")
+class HumanMessage:
+    def __init__(self, content=None, name=None):
+        self.content = content
+        self.name = name
+lang_msgs.HumanMessage = HumanMessage
+sys.modules.setdefault("langchain_core.messages", lang_msgs)
+
+lang_prompts = ModuleType("langchain_core.prompts")
+class ChatPromptTemplate:
+    @classmethod
+    def from_messages(cls, messages):
+        return cls()
+    def invoke(self, data):
+        return data
+lang_prompts.ChatPromptTemplate = ChatPromptTemplate
+sys.modules.setdefault("langchain_core.prompts", lang_prompts)
+
+# Stub langchain provider packages used by src.llm.models
+for name in [
+    "langchain_anthropic",
+    "langchain_deepseek",
+    "langchain_google_genai",
+    "langchain_groq",
+    "langchain_openai",
+    "langchain_ollama",
+]:
+    sys.modules.setdefault(name, ModuleType(name))
+
+# Add BaseMessage for graph.state imports
+class BaseMessage:
+    pass
+lang_msgs.BaseMessage = BaseMessage
+
+# Stub requests module
+requests_stub = ModuleType("requests")
+def _dummy(*a, **k):
+    raise RuntimeError("request called without patching")
+requests_stub.get = _dummy
+requests_stub.post = _dummy
+sys.modules.setdefault("requests", requests_stub)
+requests_stub.Response = type('Response', (), {})
+
+# Provide dummy classes for langchain provider stubs
+for name in [
+    "langchain_anthropic",
+    "langchain_deepseek",
+    "langchain_google_genai",
+    "langchain_groq",
+    "langchain_openai",
+    "langchain_ollama",
+]:
+    mod = sys.modules[name]
+    mod.ChatAnthropic = type('ChatAnthropic', (), {})
+    mod.ChatDeepSeek = type('ChatDeepSeek', (), {})
+    mod.ChatGoogleGenerativeAI = type('ChatGoogleGenerativeAI', (), {})
+    mod.ChatGroq = type('ChatGroq', (), {})
+    mod.ChatOpenAI = type('ChatOpenAI', (), {})
+    mod.ChatOllama = type('ChatOllama', (), {})
+import sys, types; import types; sys.modules.setdefault("numpy", types.ModuleType("numpy"))
+
+# Simplified Price and PriceResponse models
+from src.data import models as data_models
+
+class Price(BaseModel):
+    def __init__(self, **k):
+        for key, val in k.items():
+            setattr(self, key, val)
+    def model_dump(self):
+        return self.__dict__
+
+class PriceResponse(BaseModel):
+    def __init__(self, **k):
+        self.ticker = k.get('ticker')
+        self.prices = [Price(**p) for p in k.get('prices', [])]
+
+data_models.Price = Price
+data_models.PriceResponse = PriceResponse

--- a/tests/test_analysts_utils.py
+++ b/tests/test_analysts_utils.py
@@ -1,0 +1,26 @@
+from src.utils import analysts
+
+
+def test_get_analyst_nodes_keys():
+    nodes = analysts.get_analyst_nodes()
+    assert "ben_graham" in nodes
+    node_name, func = nodes["ben_graham"]
+    assert node_name == "ben_graham_agent"
+    assert callable(func)
+
+
+def test_get_agents_list_sorted():
+    agents_list = analysts.get_agents_list()
+    orders = [a["order"] for a in agents_list]
+    assert orders == sorted(orders)
+    keys = [a["key"] for a in agents_list]
+    assert set(keys) == set(analysts.ANALYST_CONFIG.keys())
+
+
+def test_get_agents_by_investing_style():
+    groups = analysts.get_agents_by_investing_style()
+    assert "value_investing" in groups
+    value_agents = [a["key"] for a in groups["value_investing"]]
+    assert "ben_graham" in value_agents
+    orders = [a["order"] for a in groups["value_investing"]]
+    assert orders == sorted(orders)

--- a/tests/test_api_rate_limiting.py
+++ b/tests/test_api_rate_limiting.py
@@ -1,3 +1,18 @@
+import sys
+from types import SimpleNamespace
+from src.data import models as data_models
+class Price:
+    def __init__(self, **k):
+        self.__dict__.update(k)
+    def model_dump(self):
+        return self.__dict__
+class PriceResponse:
+    def __init__(self, **k):
+        self.ticker = k.get("ticker")
+        self.prices = [Price(**p) for p in k.get("prices", [])]
+data_models.Price = Price
+data_models.PriceResponse = PriceResponse
+
 import os
 import pytest
 from unittest.mock import Mock, patch, call

--- a/tests/test_portfolio_manager.py
+++ b/tests/test_portfolio_manager.py
@@ -1,0 +1,38 @@
+import json
+from unittest.mock import patch
+
+from src.agents import portfolio_manager
+from src.agents.portfolio_manager import PortfolioManagerOutput, PortfolioDecision
+
+
+def test_portfolio_manager_trade_decision():
+    state = {
+        "messages": [],
+        "data": {
+            "portfolio": {"cash": 1000, "positions": {}},
+            "tickers": ["AAPL"],
+            "analyst_signals": {
+                "risk_management_agent": {
+                    "AAPL": {"remaining_position_limit": 500, "current_price": 50}
+                }
+            },
+        },
+        "metadata": {"show_reasoning": False},
+    }
+
+    pm_output = PortfolioManagerOutput(
+        decisions={
+            "AAPL": PortfolioDecision(action="buy", quantity=5, confidence=80.0, reasoning="ok")
+        }
+    )
+
+    with patch("src.agents.portfolio_manager.call_llm", return_value=pm_output) as mock_llm, \
+         patch("src.agents.portfolio_manager.progress.update_status"):
+        new_state = portfolio_manager.portfolio_management_agent(state)
+
+    mock_llm.assert_called_once()
+
+    msg = new_state["messages"][-1]
+    content = json.loads(msg.content)
+    assert content["AAPL"]["action"] == "buy"
+    assert content["AAPL"]["quantity"] == 5

--- a/tests/test_risk_manager.py
+++ b/tests/test_risk_manager.py
@@ -1,0 +1,56 @@
+import json
+from unittest.mock import patch
+
+from src.agents import risk_manager
+from src.data.models import Price
+
+class DummyILoc:
+    def __init__(self, val):
+        self.val = val
+    def __getitem__(self, idx):
+        return self.val
+
+class DummySeries:
+    def __init__(self, val):
+        self.iloc = DummyILoc(val)
+    def __getitem__(self, idx):
+        return self.iloc[idx]
+
+class DummyDF:
+    def __init__(self, close_val):
+        self.data = {"close": DummySeries(close_val)}
+    @property
+    def empty(self):
+        return False
+    def __getitem__(self, key):
+        return self.data[key]
+
+
+
+def test_risk_management_position_limits():
+    state = {
+        "messages": [],
+        "data": {
+            "portfolio": {"cash": 1000, "positions": {}},
+            "tickers": ["AAPL"],
+            "start_date": "2024-01-01",
+            "end_date": "2024-01-02",
+            "analyst_signals": {},
+        },
+        "metadata": {"show_reasoning": False},
+    }
+
+    dummy_price = Price(open=10, close=50, high=55, low=9, volume=100, time="2024-01-01T00:00:00Z")
+
+    with patch("src.agents.risk_manager.get_prices", return_value=[dummy_price]), \
+         patch("src.agents.risk_manager.prices_to_df", return_value=DummyDF(50)), \
+         patch("src.agents.risk_manager.progress.update_status"):
+        new_state = risk_manager.risk_management_agent(state)
+
+    result = new_state["data"]["analyst_signals"]["risk_management_agent"]["AAPL"]
+    assert result["remaining_position_limit"] == 200
+    assert result["current_price"] == 50
+
+    msg = new_state["messages"][-1]
+    parsed = json.loads(msg.content)
+    assert parsed["AAPL"]["remaining_position_limit"] == 200


### PR DESCRIPTION
## Summary
- add stubbed dependencies in `tests/conftest.py`
- create unit tests for `risk_manager` and `portfolio_manager`
- add tests for analyst utility helpers
- update existing API rate limit tests to patch simple price models

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866eff924c8832289879302c07a3bde